### PR TITLE
Fix link in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_ytmusic_api
 description: Unofficial YouTube Music Api for dart 
 version: 1.0.8
-repository: https://github.com/MusilyApp/dart_ytmusic_api.git
+repository: https://github.com/MusilyApp/dart_ytmusic_api
 
 environment:
   sdk: ^3.4.3


### PR DESCRIPTION
Right now the issue tracker link on pub.dev doesn't work, and I suspect this is the issue.