### PR TITLE
Duration Parser Fix.

### DIFF
--- a/lib/parsers/parser.dart
+++ b/lib/parsers/parser.dart
@@ -6,7 +6,7 @@ import 'package:dart_ytmusic_api/utils/traverse.dart';
 
 class Parser {
   static int? parseDuration(String? time) {
-    final regex = RegExp(r'\((\d{1,2}:\d{2})\)');
+    final regex = RegExp(r'(\d{1,2}:\d{2})');
     final match = regex.firstMatch(time ?? '00:00');
     if (time == null || match == null) return null;
 

--- a/lib/parsers/song_parser.dart
+++ b/lib/parsers/song_parser.dart
@@ -27,7 +27,7 @@ class SongParser {
     final columns = traverseList(item, ["flexColumns", "runs"]);
     // It is not possible to identify the title and author
     final title = columns[0];
-    final artist = columns.firstWhere(isArtist, orElse: () => columns[3]);
+    final artist = columns.firstWhere(isArtist, orElse: () => columns[1]);
     final album = columns.firstWhere(isAlbum, orElse: () => null);
     final duration = columns.firstWhere(
         (item) => isDuration(item) && item != title,


### PR DESCRIPTION
Straight from a GithubCopilot breakdown of the RegEx (because I'm too lazy):

```dart
\((\d{1,2}:\d{2})\)
```
1. `\(` and `\)`: These match the literal parentheses `(` and `)`. The backslashes `\` are escape characters that indicate the parentheses should be treated as literal characters rather than special regex characters.

2. `(\d{1,2}:\d{2})`: This is a capturing group that matches the time format. Let's break this down further:

    - `\d{1,2}`: This matches one or two digits, representing the hour part of the time. `\d` is a shorthand for any digit (0-9), and {1,2} specifies that it should match between one and two digits.

    - `:`: This matches the literal colon `:` character, which separates the hours and minutes.

    - `\d{2}`: This matches exactly two digits, representing the minute part of the time.

In summary, this regex matches a time in the format of HH:MM or H:MM enclosed in parentheses. For example, it would match (12:34) or (9:45).

I removed the `\(` & `\)` so it parses time without the literal parantheses.