### PR TITLE
fix: handle time parsing to avoid null duration

### DIFF
--- a/lib/parsers/parser.dart
+++ b/lib/parsers/parser.dart
@@ -6,13 +6,10 @@ import 'package:dart_ytmusic_api/utils/traverse.dart';
 
 class Parser {
   static int? parseDuration(String? time) {
-    final regex = RegExp(r'\((\d{1,2}:\d{2})\)');
-    final match = regex.firstMatch(time ?? '00:00');
-    if (time == null || match == null) return null;
-
-    final extractedTime = match.group(1)!;
-
-    final parts = extractedTime.split(":").reversed.map(int.parse).toList();
+    if (time == null) return null;
+    final parts = time.split(":").reversed.map(int.parse).toList();
+    if (time.length < 2) return null;
+    
     final seconds = parts[0];
     final minutes = parts[1];
     late final int hours;


### PR DESCRIPTION
## 🔧 Fix: Handle Time Parsing to Avoid Null Duration

### 🐛 Issue
Functions like `search` and `searchSongs` were returning `null` for song durations. The root cause was in the `parseDuration` function, where a regex was used unnecessarily to extract the time string, even though the `time` value was already clean (e.g., `"4:12"`). This led to failed matches and ultimately a `null` result.

Additionally, functions like `getArtistSongs` are also returning `null` durations — but in those cases, the issue is that `parseDuration` is being passed a `null` value as its parameter. This indicates that the upstream logic is not providing a valid time string.

### ✅ Changes Made
- Removed the unnecessary regex from `parseDuration`.

### 📌 Notes
- This PR fixes the parsing issue for correctly passed time strings (e.g., from `search`).
- Other features like `getArtistSongs` still need upstream fixes to ensure valid time values are passed into `parseDuration`.
